### PR TITLE
[IDLE-255] feat: 관심사 기반 도서추천 API 캐싱 처리

### DIFF
--- a/user-service/src/main/java/kr/mybrary/userservice/global/config/RedisClusterConfig.java
+++ b/user-service/src/main/java/kr/mybrary/userservice/global/config/RedisClusterConfig.java
@@ -1,16 +1,27 @@
 package kr.mybrary.userservice.global.config;
 
 
+import java.time.Duration;
+import java.util.Arrays;
 import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+import kr.mybrary.userservice.global.constant.CacheKey;
 import org.springframework.beans.factory.annotation.Value;
+import org.springframework.cache.CacheManager;
 import org.springframework.cache.annotation.EnableCaching;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Profile;
+import org.springframework.data.redis.cache.RedisCacheConfiguration;
+import org.springframework.data.redis.cache.RedisCacheManager.RedisCacheManagerBuilder;
 import org.springframework.data.redis.connection.RedisClusterConfiguration;
 import org.springframework.data.redis.connection.RedisConnectionFactory;
 import org.springframework.data.redis.connection.lettuce.LettuceConnectionFactory;
 import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.data.redis.serializer.GenericJackson2JsonRedisSerializer;
+import org.springframework.data.redis.serializer.RedisSerializationContext;
 import org.springframework.data.redis.serializer.StringRedisSerializer;
 
 @Configuration
@@ -36,6 +47,28 @@ public class RedisClusterConfig {
         redisTemplate.setHashValueSerializer(new StringRedisSerializer());
         redisTemplate.setConnectionFactory(redisConnectionFactory());
         return redisTemplate;
+    }
+
+    @Bean
+    public CacheManager cacheManager(RedisConnectionFactory cf) {
+
+        RedisCacheManagerBuilder builder = RedisCacheManagerBuilder.fromConnectionFactory(cf);
+
+        RedisCacheConfiguration configuration = RedisCacheConfiguration.defaultCacheConfig()
+                .disableCachingNullValues()
+                .entryTtl(Duration.ofDays(1L))
+                .serializeKeysWith(RedisSerializationContext.SerializationPair.fromSerializer(new StringRedisSerializer()))
+                .serializeValuesWith(RedisSerializationContext.SerializationPair.fromSerializer(new GenericJackson2JsonRedisSerializer()));
+
+        Map<String, RedisCacheConfiguration> cacheConfigurations = Arrays.stream(CacheKey.values())
+                .collect(Collectors.toMap(
+                        CacheKey::getKey,
+                        cacheKey -> RedisCacheConfiguration.defaultCacheConfig()
+                                .entryTtl(Duration.ofSeconds(cacheKey.getExpireTimeSeconds()))
+                                .prefixCacheNameWith(cacheKey.getPrefix() + "::")
+                ));
+
+        return builder.cacheDefaults(configuration).withInitialCacheConfigurations(cacheConfigurations).build();
     }
 
 }

--- a/user-service/src/main/java/kr/mybrary/userservice/global/config/RedisConfig.java
+++ b/user-service/src/main/java/kr/mybrary/userservice/global/config/RedisConfig.java
@@ -1,14 +1,26 @@
 package kr.mybrary.userservice.global.config;
 
+import kr.mybrary.userservice.global.constant.CacheKey;
 import org.springframework.beans.factory.annotation.Value;
+import org.springframework.cache.CacheManager;
 import org.springframework.cache.annotation.EnableCaching;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Profile;
+import org.springframework.data.redis.cache.RedisCacheConfiguration;
+import org.springframework.data.redis.cache.RedisCacheManager;
+import org.springframework.data.redis.connection.RedisConnectionFactory;
 import org.springframework.data.redis.connection.RedisStandaloneConfiguration;
 import org.springframework.data.redis.connection.lettuce.LettuceConnectionFactory;
 import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.data.redis.serializer.GenericJackson2JsonRedisSerializer;
+import org.springframework.data.redis.serializer.RedisSerializationContext;
 import org.springframework.data.redis.serializer.StringRedisSerializer;
+
+import java.time.Duration;
+import java.util.Arrays;
+import java.util.Map;
+import java.util.stream.Collectors;
 
 @Configuration
 @EnableCaching
@@ -35,6 +47,28 @@ public class RedisConfig {
         redisTemplate.setHashValueSerializer(new StringRedisSerializer());
         redisTemplate.setConnectionFactory(redisConnectionFactory());
         return redisTemplate;
+    }
+
+    @Bean
+    public CacheManager cacheManager(RedisConnectionFactory cf) {
+
+        RedisCacheManager.RedisCacheManagerBuilder builder = RedisCacheManager.RedisCacheManagerBuilder.fromConnectionFactory(cf);
+
+        RedisCacheConfiguration configuration = RedisCacheConfiguration.defaultCacheConfig()
+                .disableCachingNullValues()
+                .entryTtl(Duration.ofDays(1L))
+                .serializeKeysWith(RedisSerializationContext.SerializationPair.fromSerializer(new StringRedisSerializer()))
+                .serializeValuesWith(RedisSerializationContext.SerializationPair.fromSerializer(new GenericJackson2JsonRedisSerializer()));
+
+        Map<String, RedisCacheConfiguration> cacheConfigurations = Arrays.stream(CacheKey.values())
+                .collect(Collectors.toMap(
+                        CacheKey::getKey,
+                        cacheKey -> RedisCacheConfiguration.defaultCacheConfig()
+                                .entryTtl(Duration.ofSeconds(cacheKey.getExpireTimeSeconds()))
+                                .prefixCacheNameWith(cacheKey.getPrefix() + "::")
+                ));
+
+        return builder.cacheDefaults(configuration).withInitialCacheConfigurations(cacheConfigurations).build();
     }
 
 }

--- a/user-service/src/main/java/kr/mybrary/userservice/global/constant/CacheKey.java
+++ b/user-service/src/main/java/kr/mybrary/userservice/global/constant/CacheKey.java
@@ -1,0 +1,16 @@
+package kr.mybrary.userservice.global.constant;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public enum CacheKey {
+
+    INTEREST_BASED_BOOK_RECOMMENDATION("bookRecommendation", "interestBased", CacheTTL.ONE_WEEK.getExpireTimeSeconds());
+
+    private final String prefix;
+    private final String key;
+    private final int expireTimeSeconds;
+
+}

--- a/user-service/src/main/java/kr/mybrary/userservice/global/constant/CacheTTL.java
+++ b/user-service/src/main/java/kr/mybrary/userservice/global/constant/CacheTTL.java
@@ -1,0 +1,17 @@
+package kr.mybrary.userservice.global.constant;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public enum CacheTTL {
+
+    ONE_MONTH(60 * 60 * 24 * 30),
+    ONE_WEEK(60 * 60 * 24 * 7),
+    ONE_DAY(60 * 60 * 24),
+    ONE_HOUR(60 * 60),
+    ONE_MIN(60);
+
+    private final int expireTimeSeconds;
+}

--- a/user-service/src/main/java/kr/mybrary/userservice/interest/domain/InterestServiceImpl.java
+++ b/user-service/src/main/java/kr/mybrary/userservice/interest/domain/InterestServiceImpl.java
@@ -25,6 +25,7 @@ import kr.mybrary.userservice.interest.persistence.repository.UserInterestReposi
 import kr.mybrary.userservice.user.domain.UserService;
 import kr.mybrary.userservice.user.persistence.User;
 import lombok.RequiredArgsConstructor;
+import org.springframework.cache.annotation.CacheEvict;
 import org.springframework.cache.annotation.Cacheable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -78,6 +79,8 @@ public class InterestServiceImpl implements InterestService {
     }
 
     @Override
+    @CacheEvict(cacheNames = "interestBased", key = "#request.loginId + '_' + #request.type + '_' + #request.page",
+            allEntries = true, cacheManager = "cacheManager")
     public UserInterestServiceResponse updateUserInterests(UserInterestUpdateServiceRequest request) {
         checkUserInterestUpdateRequestAuthentication(request);
         checkUserInterestUpdateRequestSize(request);

--- a/user-service/src/main/java/kr/mybrary/userservice/interest/domain/InterestServiceImpl.java
+++ b/user-service/src/main/java/kr/mybrary/userservice/interest/domain/InterestServiceImpl.java
@@ -25,6 +25,7 @@ import kr.mybrary.userservice.interest.persistence.repository.UserInterestReposi
 import kr.mybrary.userservice.user.domain.UserService;
 import kr.mybrary.userservice.user.persistence.User;
 import lombok.RequiredArgsConstructor;
+import org.springframework.cache.annotation.Cacheable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -90,6 +91,7 @@ public class InterestServiceImpl implements InterestService {
 
     @Override
     @Transactional(readOnly = true)
+    @Cacheable(cacheNames = "interestBased", key = "#request.loginId + '_' + #request.type + '_' + #request.page", cacheManager = "cacheManager")
     public UserInterestAndBookRecommendationsResponse getInterestsAndBookRecommendations(
             UserInterestAndBookRecommendationsServiceRequest request) {
 

--- a/user-service/src/main/java/kr/mybrary/userservice/interest/domain/dto/response/UserInterestAndBookRecommendationsResponse.java
+++ b/user-service/src/main/java/kr/mybrary/userservice/interest/domain/dto/response/UserInterestAndBookRecommendationsResponse.java
@@ -1,5 +1,6 @@
 package kr.mybrary.userservice.interest.domain.dto.response;
 
+import java.io.Serializable;
 import java.util.List;
 import kr.mybrary.userservice.client.book.dto.response.BookRecommendationsServiceResponse.BookRecommendationsResponseElement;
 import kr.mybrary.userservice.interest.persistence.Interest;
@@ -9,14 +10,14 @@ import org.jetbrains.annotations.NotNull;
 
 @Getter
 @Builder
-public class UserInterestAndBookRecommendationsResponse {
+public class UserInterestAndBookRecommendationsResponse implements Serializable {
 
     private List<UserInterestElement> userInterests;
     private List<BookRecommendationElement> bookRecommendations;
 
     @Getter
     @Builder
-    public static class UserInterestElement {
+    public static class UserInterestElement implements Serializable {
 
         private String name;
         private int code;
@@ -24,7 +25,7 @@ public class UserInterestAndBookRecommendationsResponse {
 
     @Getter
     @Builder
-    public static class BookRecommendationElement {
+    public static class BookRecommendationElement implements Serializable {
 
         private String thumbnailUrl;
         private String isbn13;


### PR DESCRIPTION
## 🧑‍💻 작업 사항

## 캐싱 처리
- Look Aside + Write Around 전략을 적용했습니다.
  - 사용자의 관심사 기반 도서추천 데이터가 캐시에 있으면 캐시에서 가져오고
  - 캐시에 없으면 DB에서 가져온 뒤 캐시에 저장합니다.

  - 사용자 관심사 업데이트 발생 시, 해당 사용자의 관심사 기반 도서추천 데이터를 캐시에서 삭제합니다.
 
- 캐시 키 설정
  - 추천구분::추천기반::사용자ID_타입_조회페이지
  - 예) bookRecommendation::interestBased::loginId_Bestseller_1

- TTL 설정
  - 우선 도서 검색 캐시 적용 시 설정된 TTL과 동일하게 1주일로 설정했습니다.

### 캐시 적용 전 응답 시간 259ms
![image](https://github.com/SWM-IDLE/mybrary-user-service/assets/78717113/a931e2c5-9a82-443b-98ce-4761d3582668)

### 캐시 적용 후 응답 시간 24ms
![image](https://github.com/SWM-IDLE/mybrary-user-service/assets/78717113/5182e3db-2f59-4daf-949c-01f60c26e36a)

### 캐시 삭제 by CacheEvict
![image](https://github.com/SWM-IDLE/mybrary-user-service/assets/78717113/b4bd833e-b0b4-4e0f-b4d4-861f410a5af0)

<br><br>

## 🔗 링크


<br><br>

## 🐰 시급한 정도

🐢 천천히 : 급하지 않습니다.

<br><br>

## 📖 참고 사항

**어떤 API에 캐시를 적용할까?** 에 대해 고민해본 사항들입니다
- 사용자 검색 API
    - 특정 사용자가 닉네임을 바꾸면 데이터 정합성 문제가 분명히 발생할 것
        - 동기화를 고려해서 설계 필요
- 프로필 정보 조회 API
    - 자주 조회되지만 데이터 자체가 크지 않음
        - 캐시 적용 대신 인덱스만 추가해주어도 되지 않을까?
        - 그래도 DB 접근 자체를 줄이는 것이 나아 보여서 다음에 캐시 적용 예정
- 관심사 기반 책 추천 API
    - 메인 화면에서 자주 조회되면서 데이터가 은근 큼  (책 10건에 대한 썸네일 url과 제목)
        - Look Aside + Write Around 전략으로 캐시 적용 ✅
