### PR TITLE
[IDLE-237] feat: 블루/그린 무중단 배포 도입

### DIFF
--- a/.github/workflows/user-service-ecr-ecs.yml
+++ b/.github/workflows/user-service-ecr-ecs.yml
@@ -8,7 +8,7 @@ on:
       - 'user-service/**'
 
 jobs:
-  deploy:
+  build:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout Repository
@@ -82,4 +82,25 @@ jobs:
           docker build --platform amd64 -t $ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG .
           docker push $ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG
           echo "image=$ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG" >> $GITHUB_OUTPUT
+
+  deploy:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Fill in the new image ID in the Amazon ECS task definition
+        id: task-def
+        uses: aws-actions/amazon-ecs-render-task-definition@v1
+        with:
+          task-definition: ./user-service/task-definition.json
+          container-name: userService
+          image: ${{ steps.build-image.outputs.image }}
+
+      - name: Deploy Amazon ECS task definition
+        uses: aws-actions/amazon-ecs-deploy-task-definition@v1
+        with:
+          task-definition: ${{ steps.task-def.outputs.task-definition }}
+          service: userService-EcsService
+          cluster: MybraryCluster
+          codedeploy-deployment-group: DgpECS-MybraryCluster-userService-EcsService
+          codedeploy-appspec: ./user-service/appspec.yaml
+          wait-for-service-stability: true
 

--- a/user-service/Dockerfile
+++ b/user-service/Dockerfile
@@ -1,8 +1,4 @@
 FROM openjdk:21-ea-17-jdk-slim
 COPY build/libs/user-service-0.0.1-SNAPSHOT.jar user-service.jar
 
-RUN apt update && apt install curl -y && apt install jq -y
-COPY entrypoint.sh /usr/local/bin/
-
-RUN chmod +x /usr/local/bin/entrypoint.sh
-ENTRYPOINT ["/usr/local/bin/entrypoint.sh"]
+CMD ["java", "-jar", "user-service.jar"]

--- a/user-service/appspec.yaml
+++ b/user-service/appspec.yaml
@@ -1,0 +1,10 @@
+version: 0.0
+Resources:
+  - TargetService:
+      Type: AWS::ECS::Service
+      Properties:
+        TaskDefinition: taskDefinition
+        LoadBalancerInfo:
+          ContainerName: userService
+          ContainerPort: 80
+        PlatformVersion: "LATEST"

--- a/user-service/entrypoint.sh
+++ b/user-service/entrypoint.sh
@@ -1,7 +1,0 @@
-#!/bin/bash
-
-response=$(curl -s ${ECS_CONTAINER_METADATA_URI_V4})
-export ECS_INSTANCE_IP_ADDRESS=$(echo $response | jq -r '.Networks[0].IPv4Addresses[0]')
-echo $ECS_INSTANCE_IP_ADDRESS
-
-java -jar user-service.jar

--- a/user-service/src/main/java/kr/mybrary/userservice/authentication/domain/oauth2/OAuthAttributes.java
+++ b/user-service/src/main/java/kr/mybrary/userservice/authentication/domain/oauth2/OAuthAttributes.java
@@ -76,7 +76,6 @@ public class OAuthAttributes {
                 .password(UUID.randomUUID().toString())
                 .email(oAuth2UserInfo.getEmail())
                 .nickname(oAuth2UserInfo.getNickname() + RandomStringUtils.randomNumeric(5))
-                .profileImageUrl(oAuth2UserInfo.getImageUrl())
                 .introduction("")
                 .role(Role.USER)
                 .build();

--- a/user-service/src/main/java/kr/mybrary/userservice/authentication/domain/oauth2/userinfo/GoogleOAuth2UserInfo.java
+++ b/user-service/src/main/java/kr/mybrary/userservice/authentication/domain/oauth2/userinfo/GoogleOAuth2UserInfo.java
@@ -19,11 +19,6 @@ public class GoogleOAuth2UserInfo extends OAuth2UserInfo {
     }
 
     @Override
-    public String getImageUrl() {
-        return (String) attributes.get("picture");
-    }
-
-    @Override
     public String getEmail() {
         return (String) attributes.get("email");
     }

--- a/user-service/src/main/java/kr/mybrary/userservice/authentication/domain/oauth2/userinfo/KakaoOAuth2UserInfo.java
+++ b/user-service/src/main/java/kr/mybrary/userservice/authentication/domain/oauth2/userinfo/KakaoOAuth2UserInfo.java
@@ -23,15 +23,6 @@ public class KakaoOAuth2UserInfo extends OAuth2UserInfo {
     }
 
     @Override
-    public String getImageUrl() {
-        Map<String, Object> profile = getProfile();
-        if (profile == null) {
-            return null;
-        }
-        return (String) profile.get("profile_image_url");
-    }
-
-    @Override
     public String getEmail() {
         Map<String, Object> account = (Map<String, Object>) attributes.get("kakao_account");
         if (account == null) {

--- a/user-service/src/main/java/kr/mybrary/userservice/authentication/domain/oauth2/userinfo/NaverOAuth2UserInfo.java
+++ b/user-service/src/main/java/kr/mybrary/userservice/authentication/domain/oauth2/userinfo/NaverOAuth2UserInfo.java
@@ -30,17 +30,6 @@ public class NaverOAuth2UserInfo extends OAuth2UserInfo {
     }
 
     @Override
-    public String getImageUrl() {
-        Map<String, Object> response = getResponse();
-
-        if (response == null) {
-            return null;
-        }
-
-        return (String) response.get("profile_image");
-    }
-
-    @Override
     public String getEmail() {
         Map<String, Object> response = getResponse();
 

--- a/user-service/src/main/java/kr/mybrary/userservice/authentication/domain/oauth2/userinfo/OAuth2UserInfo.java
+++ b/user-service/src/main/java/kr/mybrary/userservice/authentication/domain/oauth2/userinfo/OAuth2UserInfo.java
@@ -14,8 +14,6 @@ public abstract class OAuth2UserInfo {
 
     public abstract String getNickname();
 
-    public abstract String getImageUrl();
-
     public abstract String getEmail();
 
 }

--- a/user-service/src/main/java/kr/mybrary/userservice/client/book/api/BookServiceClient.java
+++ b/user-service/src/main/java/kr/mybrary/userservice/client/book/api/BookServiceClient.java
@@ -6,7 +6,7 @@ import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestParam;
 
-@FeignClient(name = "book-service")
+@FeignClient(name = "bookClient")
 public interface BookServiceClient {
 
     @GetMapping("/api/v1/books/recommendations/{type}/categories/{categoryId}")

--- a/user-service/task-definition.json
+++ b/user-service/task-definition.json
@@ -1,0 +1,95 @@
+{
+  "taskDefinitionArn": "arn:aws:ecs:ap-northeast-2:133172301128:task-definition/userServiceFamily:18",
+  "containerDefinitions": [
+    {
+      "name": "userService",
+      "image": "133172301128.dkr.ecr.ap-northeast-2.amazonaws.com/user-service",
+      "cpu": 1024,
+      "portMappings": [
+        {
+          "name": "userservice-80-tcp",
+          "containerPort": 80,
+          "hostPort": 80,
+          "protocol": "tcp",
+          "appProtocol": "http"
+        }
+      ],
+      "essential": true,
+      "environment": [
+        {
+          "name": "CONFIG_SERVER_URI",
+          "value": "http://10.0.3.105:8888"
+        }
+      ],
+      "mountPoints": [],
+      "volumesFrom": [],
+      "logConfiguration": {
+        "logDriver": "awslogs",
+        "options": {
+          "awslogs-create-group": "true",
+          "awslogs-group": "/ecs/userServiceFamily",
+          "awslogs-region": "ap-northeast-2",
+          "awslogs-stream-prefix": "ecs"
+        }
+      }
+    }
+  ],
+  "family": "userServiceFamily",
+  "taskRoleArn": "arn:aws:iam::133172301128:role/ecsTaskExecutionRole",
+  "executionRoleArn": "arn:aws:iam::133172301128:role/ecsTaskExecutionRole",
+  "networkMode": "awsvpc",
+  "revision": 18,
+  "volumes": [],
+  "status": "ACTIVE",
+  "requiresAttributes": [
+    {
+      "name": "com.amazonaws.ecs.capability.logging-driver.awslogs"
+    },
+    {
+      "name": "ecs.capability.execution-role-awslogs"
+    },
+    {
+      "name": "com.amazonaws.ecs.capability.ecr-auth"
+    },
+    {
+      "name": "com.amazonaws.ecs.capability.docker-remote-api.1.19"
+    },
+    {
+      "name": "com.amazonaws.ecs.capability.task-iam-role"
+    },
+    {
+      "name": "ecs.capability.execution-role-ecr-pull"
+    },
+    {
+      "name": "com.amazonaws.ecs.capability.docker-remote-api.1.18"
+    },
+    {
+      "name": "ecs.capability.task-eni"
+    },
+    {
+      "name": "com.amazonaws.ecs.capability.docker-remote-api.1.29"
+    }
+  ],
+  "placementConstraints": [],
+  "compatibilities": [
+    "EC2",
+    "FARGATE"
+  ],
+  "requiresCompatibilities": [
+    "FARGATE"
+  ],
+  "cpu": "1024",
+  "memory": "2048",
+  "runtimePlatform": {
+    "cpuArchitecture": "X86_64",
+    "operatingSystemFamily": "LINUX"
+  },
+  "registeredAt": "2023-09-14T06:34:52.728Z",
+  "registeredBy": "arn:aws:iam::133172301128:user/soma1415",
+  "tags": [
+    {
+      "key": "Name",
+      "value": "userService"
+    }
+  ]
+}


### PR DESCRIPTION
## 🧑‍💻 작업 사항
### 추가 및 수정된 파일
- task-definition.json
  - ECS에서 서비스를 실행하기 위한 테스크 정의 파일
  - Github Actions workflow의 Deploy 단계에서 이미지 ID가 업데이트됨
 
- appspec.yaml
  - Code Deploy에서 배포 설정을 하기 위한 파일

- user-service-ecr-ecs.yml
  - Deploy job 추가
  - Fill in the new image ID in the Amazon ECS task definition: 테스크 정의 파일에서 이미지 ID 업데이트
  - Deploy Amazon ECS task definition: code deploy의 배포 그룹에서 새로운 배포 진행

- Dockerfile
  - 서비스 디스커버리 및 로드 밸런싱을 Eureka 서버 대신 AWS ALB로 대체 (완료된 이슈)
  - 따라서 기존 Eureka 클라이언트 등록을 위해 ECS 컨테이너 메타데이터를 호출한 entrypoint.sh가 불필요해져서 삭제함

### Hotfix
- BookServiceClient name 수정
  - Eureka 서버를 사용하지 않게 되면서 클라이언트 URL 지정이 필요해짐
  - Config 레포지토리의 userservice-prod.yml 에서 URL을 읽어올 수 있도록 클라이언트 name 수정
  
- OAuth2UserInfo 프로필 이미지 요청 함수 제거
  - 소셜 로그인 시 각 플랫폼 별 프로필 이미지를 가져오지 않고 마이브러리 디폴트 이미지 적용 (완료된 이슈)
  - 따라서 소셜 로그인 동의 항목에서 프로필 이미지가 제거됨에 따라 코드상에서도 getProfileImage 함수 제거

<br><br>

## 🔗 링크


<br><br>

## 🐰 시급한 정도

🚨 긴급 : 선 어프루브 후 리뷰를 부탁드립니다. (리뷰는 추후 반영)


<br><br>

## 📖 참고 사항
https://github.com/janeljs/ECS_Fargate_Deploy_Example
