### PR TITLE
[IDLE-261] feat: 소셜 로그인 이메일 조회 API 개발

### DIFF
--- a/user-service/src/main/java/kr/mybrary/userservice/authentication/domain/exception/AppleClientSecretFormatException.java
+++ b/user-service/src/main/java/kr/mybrary/userservice/authentication/domain/exception/AppleClientSecretFormatException.java
@@ -6,7 +6,7 @@ public class AppleClientSecretFormatException extends ApplicationException {
 
     private static final int STATUS = 500;
     private static final String ERROR_CODE = "A-11";
-    private static final String ERROR_MESSAGE = "Apple Client Secret 설정값의 형식이 올바르지 않습니다.";
+    private static final String ERROR_MESSAGE = "Apple_Client_Secret_Format_Error";
 
     public AppleClientSecretFormatException() {
         super(STATUS, ERROR_CODE, ERROR_MESSAGE);

--- a/user-service/src/main/java/kr/mybrary/userservice/authentication/domain/exception/AppleClientSecretNotCreatedException.java
+++ b/user-service/src/main/java/kr/mybrary/userservice/authentication/domain/exception/AppleClientSecretNotCreatedException.java
@@ -6,7 +6,7 @@ public class AppleClientSecretNotCreatedException extends ApplicationException {
 
     private static final int STATUS = 500;
     private static final String ERROR_CODE = "A-07";
-    private static final String ERROR_MESSAGE = "Apple Client Secret을 생성하는데 실패했습니다.";
+    private static final String ERROR_MESSAGE = "Apple_Client_Secret_Not_Created";
 
     public AppleClientSecretNotCreatedException() {
         super(STATUS, ERROR_CODE, ERROR_MESSAGE);

--- a/user-service/src/main/java/kr/mybrary/userservice/authentication/domain/exception/AppleCodeNotFoundException.java
+++ b/user-service/src/main/java/kr/mybrary/userservice/authentication/domain/exception/AppleCodeNotFoundException.java
@@ -6,7 +6,7 @@ public class AppleCodeNotFoundException extends ApplicationException {
 
     private static final int STATUS = 404;
     private static final String ERROR_CODE = "A-06";
-    private static final String ERROR_MESSAGE = "Apple 인증 코드를 찾을 수 없습니다.";
+    private static final String ERROR_MESSAGE = "Apple_Code_Not_Found";
 
     public AppleCodeNotFoundException() {
         super(STATUS, ERROR_CODE, ERROR_MESSAGE);

--- a/user-service/src/main/java/kr/mybrary/userservice/authentication/domain/exception/ApplePrivateKeyReadException.java
+++ b/user-service/src/main/java/kr/mybrary/userservice/authentication/domain/exception/ApplePrivateKeyReadException.java
@@ -6,7 +6,7 @@ public class ApplePrivateKeyReadException extends ApplicationException {
 
     private static final int STATUS = 500;
     private static final String ERROR_CODE = "A-08";
-    private static final String ERROR_MESSAGE = "Apple Private Key를 읽어오는데 실패했습니다.";
+    private static final String ERROR_MESSAGE = "Apple_Private_Key_Read_Error";
 
     public ApplePrivateKeyReadException() {
         super(STATUS, ERROR_CODE, ERROR_MESSAGE);

--- a/user-service/src/main/java/kr/mybrary/userservice/authentication/domain/exception/AppleTokenParseException.java
+++ b/user-service/src/main/java/kr/mybrary/userservice/authentication/domain/exception/AppleTokenParseException.java
@@ -6,7 +6,7 @@ public class AppleTokenParseException extends ApplicationException {
 
     private static final int STATUS = 500;
     private static final String ERROR_CODE = "A-09";
-    private static final String ERROR_MESSAGE = "Apple 토큰을 파싱하는데 실패했습니다.";
+    private static final String ERROR_MESSAGE = "Apple_Token_Parse_Error";
 
     public AppleTokenParseException() {
         super(STATUS, ERROR_CODE, ERROR_MESSAGE);

--- a/user-service/src/main/java/kr/mybrary/userservice/authentication/domain/exception/AppleUserInfoReadException.java
+++ b/user-service/src/main/java/kr/mybrary/userservice/authentication/domain/exception/AppleUserInfoReadException.java
@@ -6,7 +6,7 @@ public class AppleUserInfoReadException extends ApplicationException {
 
     private static final int STATUS = 500;
     private static final String ERROR_CODE = "A-10";
-    private static final String ERROR_MESSAGE = "Apple 사용자 정보를 읽어오는데 실패했습니다.";
+    private static final String ERROR_MESSAGE = "Apple_User_Info_Read_Error";
 
     public AppleUserInfoReadException() {
         super(STATUS, ERROR_CODE, ERROR_MESSAGE);

--- a/user-service/src/main/java/kr/mybrary/userservice/authentication/domain/exception/AppleUserNotFoundException.java
+++ b/user-service/src/main/java/kr/mybrary/userservice/authentication/domain/exception/AppleUserNotFoundException.java
@@ -6,7 +6,7 @@ public class AppleUserNotFoundException extends ApplicationException {
 
     private static final int STATUS = 404;
     private static final String ERROR_CODE = "A-05";
-    private static final String ERROR_MESSAGE = "Apple 사용자를 찾을 수 없습니다.";
+    private static final String ERROR_MESSAGE = "Apple_User_Not_Found";
 
     public AppleUserNotFoundException() {
         super(STATUS, ERROR_CODE, ERROR_MESSAGE);

--- a/user-service/src/main/java/kr/mybrary/userservice/authentication/domain/oauth2/OAuth2Exception.java
+++ b/user-service/src/main/java/kr/mybrary/userservice/authentication/domain/oauth2/OAuth2Exception.java
@@ -7,7 +7,7 @@ import lombok.RequiredArgsConstructor;
 @RequiredArgsConstructor
 public enum OAuth2Exception {
 
-    SOCIAL_LOGIN_FAILED("U-08", "소셜 로그인에 실패하였습니다: %s");
+    SOCIAL_LOGIN_FAILED("U-08", "OAuth2 Login Failed: %s");
 
     private final String errorCode;
     private final String errorMessage;

--- a/user-service/src/main/java/kr/mybrary/userservice/authentication/domain/oauth2/handler/OAuth2LoginFailureHandler.java
+++ b/user-service/src/main/java/kr/mybrary/userservice/authentication/domain/oauth2/handler/OAuth2LoginFailureHandler.java
@@ -2,46 +2,38 @@ package kr.mybrary.userservice.authentication.domain.oauth2.handler;
 
 import static kr.mybrary.userservice.authentication.domain.oauth2.OAuth2Exception.SOCIAL_LOGIN_FAILED;
 
-import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import java.io.IOException;
-import java.util.HashMap;
-import java.util.Map;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.security.core.AuthenticationException;
 import org.springframework.security.oauth2.core.OAuth2AuthenticationException;
 import org.springframework.security.web.authentication.AuthenticationFailureHandler;
 import org.springframework.stereotype.Component;
+import org.springframework.web.util.UriComponentsBuilder;
 
 @Component
 @Slf4j
 public class OAuth2LoginFailureHandler implements AuthenticationFailureHandler {
 
-    static final String ENCODING_UTF_8 = "UTF-8";
-    static final String CONTENT_TYPE_JSON = "application/json";
-
-    @Autowired
-    private ObjectMapper objectMapper;
+    static final String CALLBACK_URL = "kr.mybrary://";
+    static final String ERROR_CODE = "errorCode";
+    static final String ERROR_MESSAGE = "errorMessage";
 
     @Override
     public void onAuthenticationFailure(HttpServletRequest request, HttpServletResponse response,
             AuthenticationException exception) throws IOException {
         log.info("OAuth2 Login Failure Handler 실행 - OAuth2 로그인 실패 : " + exception.getMessage());
-        response.setStatus(HttpServletResponse.SC_BAD_REQUEST);
-        response.setCharacterEncoding(ENCODING_UTF_8);
-        response.setContentType(CONTENT_TYPE_JSON);
-        response.getWriter().write(generateResponseBody(exception));
-    }
 
-    private String generateResponseBody(AuthenticationException exception)
-            throws JsonProcessingException {
-        Map<String, String> responseMessage = new HashMap<>();
-        responseMessage.put("errorCode", getErrorCode(exception));
-        responseMessage.put("errorMessage", getErrorMessage(exception));
-        return objectMapper.writeValueAsString(responseMessage);
+        String url = UriComponentsBuilder.fromUriString(CALLBACK_URL)
+                .queryParam(ERROR_CODE, getErrorCode(exception))
+                .queryParam(ERROR_MESSAGE, getErrorMessage(exception))
+                .toUriString();
+
+        response.sendRedirect(url);
+        log.info("Redirect Url: " + url);
     }
 
     private String getErrorCode(AuthenticationException exception) {

--- a/user-service/src/main/java/kr/mybrary/userservice/authentication/domain/oauth2/handler/OAuth2LoginFailureHandler.java
+++ b/user-service/src/main/java/kr/mybrary/userservice/authentication/domain/oauth2/handler/OAuth2LoginFailureHandler.java
@@ -1,18 +1,17 @@
 package kr.mybrary.userservice.authentication.domain.oauth2.handler;
 
-import static kr.mybrary.userservice.authentication.domain.oauth2.OAuth2Exception.SOCIAL_LOGIN_FAILED;
-
-import com.fasterxml.jackson.databind.ObjectMapper;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
-import java.io.IOException;
 import lombok.extern.slf4j.Slf4j;
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.security.core.AuthenticationException;
 import org.springframework.security.oauth2.core.OAuth2AuthenticationException;
 import org.springframework.security.web.authentication.AuthenticationFailureHandler;
 import org.springframework.stereotype.Component;
 import org.springframework.web.util.UriComponentsBuilder;
+
+import java.io.IOException;
+
+import static kr.mybrary.userservice.authentication.domain.oauth2.OAuth2Exception.SOCIAL_LOGIN_FAILED;
 
 @Component
 @Slf4j

--- a/user-service/src/main/java/kr/mybrary/userservice/user/domain/UserService.java
+++ b/user-service/src/main/java/kr/mybrary/userservice/user/domain/UserService.java
@@ -19,6 +19,8 @@ public interface UserService {
 
     ProfileImageUrlServiceResponse deleteProfileImage(ProfileImageUpdateServiceRequest serviceRequest);
 
+    ProfileEmailServiceResponse getProfileEmail(String loginId);
+
     FollowerServiceResponse getFollowers(String loginId);
 
     FollowingServiceResponse getFollowings(String loginId);

--- a/user-service/src/main/java/kr/mybrary/userservice/user/domain/UserServiceImpl.java
+++ b/user-service/src/main/java/kr/mybrary/userservice/user/domain/UserServiceImpl.java
@@ -244,6 +244,23 @@ public class UserServiceImpl implements UserService {
 
     @Override
     @Transactional(readOnly = true)
+    public ProfileEmailServiceResponse getProfileEmail(String loginId) {
+        return ProfileEmailServiceResponse.builder()
+                .email(getUserEmail(loginId))
+                .build();
+    }
+
+    @NotNull
+    private String getUserEmail(String loginId) {
+        User user = getUser(loginId);
+        if(user.getEmail() == null) {
+            return "";
+        }
+        return user.getEmail();
+    }
+
+    @Override
+    @Transactional(readOnly = true)
     public FollowerServiceResponse getFollowers(String loginId) {
         return FollowerServiceResponse.builder()
                 .userId(loginId)

--- a/user-service/src/main/java/kr/mybrary/userservice/user/domain/UserServiceImpl.java
+++ b/user-service/src/main/java/kr/mybrary/userservice/user/domain/UserServiceImpl.java
@@ -253,7 +253,7 @@ public class UserServiceImpl implements UserService {
     @NotNull
     private String getUserEmail(String loginId) {
         User user = getUser(loginId);
-        if(user.getEmail() == null) {
+        if(!user.hasEmail()) {
             return "";
         }
         return user.getEmail();

--- a/user-service/src/main/java/kr/mybrary/userservice/user/domain/dto/response/ProfileEmailServiceResponse.java
+++ b/user-service/src/main/java/kr/mybrary/userservice/user/domain/dto/response/ProfileEmailServiceResponse.java
@@ -1,0 +1,12 @@
+package kr.mybrary.userservice.user.domain.dto.response;
+
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class ProfileEmailServiceResponse {
+
+    private String email;
+
+}

--- a/user-service/src/main/java/kr/mybrary/userservice/user/persistence/User.java
+++ b/user-service/src/main/java/kr/mybrary/userservice/user/persistence/User.java
@@ -98,6 +98,10 @@ public class User extends BaseEntity {
         this.profileImageThumbnailSmallUrl = profileImageThumbnailSmallUrl;
     }
 
+    public boolean hasEmail() {
+        return this.email != null;
+    }
+
     public void follow(User target) {
         Follow follow = Follow.builder()
             .source(this)

--- a/user-service/src/main/java/kr/mybrary/userservice/user/presentation/UserController.java
+++ b/user-service/src/main/java/kr/mybrary/userservice/user/presentation/UserController.java
@@ -81,6 +81,15 @@ public class UserController {
         );
     }
 
+    @GetMapping("/{userId}/profile/email")
+    public ResponseEntity<SuccessResponse<ProfileEmailServiceResponse>> getProfileEmail(
+            @PathVariable("userId") String userId) {
+        return ResponseEntity.ok().body(
+                SuccessResponse.of(HttpStatus.OK.toString(), "사용자의 로그인된 이메일 계정을 조회했습니다.",
+                        userService.getProfileEmail(userId))
+        );
+    }
+
     @GetMapping("/{userId}/followers")
     public ResponseEntity<SuccessResponse<FollowerServiceResponse>> getFollowers(
             @PathVariable("userId") String userId) {

--- a/user-service/src/test/java/kr/mybrary/userservice/authentication/domain/oauth2/service/AppleOAuth2UserServiceTest.java
+++ b/user-service/src/test/java/kr/mybrary/userservice/authentication/domain/oauth2/service/AppleOAuth2UserServiceTest.java
@@ -103,13 +103,10 @@ class AppleOAuth2UserServiceTest {
         MockHttpServletRequest request = new MockHttpServletRequest();
 
         // when
-        assertThatThrownBy(() -> appleOAuth2UserService.authenticateWithApple(request))
-                .isInstanceOf(AppleCodeNotFoundException.class)
-                .hasFieldOrPropertyWithValue("status", 404)
-                .hasFieldOrPropertyWithValue("errorCode", "A-06")
-                .hasFieldOrPropertyWithValue("errorMessage", "Apple 인증 코드를 찾을 수 없습니다.");
+        String redirectUrl = appleOAuth2UserService.authenticateWithApple(request);
 
         // then
+        assertEquals("kr.mybrary://?errorCode=A-06&errorMessage=Apple_Code_Not_Found", redirectUrl);
         verify(appleOAuth2ServiceClient, never()).getAppleToken(anyString(), anyString(), anyString(), anyString(), anyString());
     }
 
@@ -133,13 +130,11 @@ class AppleOAuth2UserServiceTest {
         given(objectMapper.convertValue(any(), (Class<Object>) any())).willReturn(mock(JSONObject.class));
         given(userRepository.findBySocialTypeAndSocialId(any(), any())).willReturn(Optional.empty());
 
-        // then
-        assertThatThrownBy(() -> appleOAuth2UserService.authenticateWithApple(request))
-                .isInstanceOf(AppleUserNotFoundException.class)
-                .hasFieldOrPropertyWithValue("status", 404)
-                .hasFieldOrPropertyWithValue("errorCode", "A-05")
-                .hasFieldOrPropertyWithValue("errorMessage", "Apple 사용자를 찾을 수 없습니다.");
+        // when
+        String redirectUrl = appleOAuth2UserService.authenticateWithApple(request);
 
+        // then
+        assertEquals("kr.mybrary://?errorCode=A-05&errorMessage=Apple_User_Not_Found", redirectUrl);
         verify(appleOAuth2ServiceClient, times(1)).getAppleToken(anyString(), anyString(), anyString(), anyString(), anyString());
         verify(appleOAuth2UtilService, times(1)).createAppleClientSecret(anyString(), anyString());
         verify(objectMapper, times(1)).convertValue(any(), (Class<Object>) any());
@@ -199,13 +194,10 @@ class AppleOAuth2UserServiceTest {
         request.setParameter("user", "user");
 
         // when
-        assertThatThrownBy(() -> appleOAuth2UserService.authenticateWithApple(request))
-                .isInstanceOf(AppleCodeNotFoundException.class)
-                .hasFieldOrPropertyWithValue("status", 404)
-                .hasFieldOrPropertyWithValue("errorCode", "A-06")
-                .hasFieldOrPropertyWithValue("errorMessage", "Apple 인증 코드를 찾을 수 없습니다.");
+        String redirectUrl = appleOAuth2UserService.authenticateWithApple(request);
 
         // then
+        assertEquals("kr.mybrary://?errorCode=A-06&errorMessage=Apple_Code_Not_Found", redirectUrl);
         verify(appleOAuth2ServiceClient, never()).getAppleToken(anyString(), anyString(), anyString(), anyString(), anyString());
     }
 
@@ -219,13 +211,10 @@ class AppleOAuth2UserServiceTest {
         given(objectMapper.readValue("user", AppleOAuth2UserInfo.class)).willThrow(JsonProcessingException.class);
 
         // when
-        assertThatThrownBy(() -> appleOAuth2UserService.authenticateWithApple(request))
-                .isInstanceOf(AppleUserInfoReadException.class)
-                .hasFieldOrPropertyWithValue("status", 500)
-                .hasFieldOrPropertyWithValue("errorCode", "A-10")
-                .hasFieldOrPropertyWithValue("errorMessage", "Apple 사용자 정보를 읽어오는데 실패했습니다.");
+        String redirectUrl = appleOAuth2UserService.authenticateWithApple(request);
 
         // then
+        assertEquals("kr.mybrary://?errorCode=A-10&errorMessage=Apple_User_Info_Read_Error", redirectUrl);
         verify(appleOAuth2ServiceClient, never()).getAppleToken(anyString(), anyString(), anyString(), anyString(), anyString());
         verify(objectMapper, times(1)).readValue("user", AppleOAuth2UserInfo.class);
     }

--- a/user-service/src/test/java/kr/mybrary/userservice/user/UserFixture.java
+++ b/user-service/src/test/java/kr/mybrary/userservice/user/UserFixture.java
@@ -47,6 +47,11 @@ public enum UserFixture {
     USER_WITH_SIMILAR_NICKNAME(2L, "loginId123", "nickname123", "encodedPassword", Role.USER,
             "socialId123", SocialType.GOOGLE, "email@mail.com", "introduction", "profileImageUrl",
             "profileImageThumbnailTinyUrl", "profileImageThumbnailSmallUrl",
+            Collections.emptyList(), Collections.emptyList()),
+
+    USER_WITH_NO_EMAIL(1L, "loginId", "nickname", "encodedPassword", Role.USER,
+            "socialId", SocialType.GOOGLE, null, "introduction", "profileImageUrl",
+            "profileImageThumbnailTinyUrl", "profileImageThumbnailSmallUrl",
             Collections.emptyList(), Collections.emptyList());
 
     private final Long id;

--- a/user-service/src/test/java/kr/mybrary/userservice/user/domain/UserServiceImplTest.java
+++ b/user-service/src/test/java/kr/mybrary/userservice/user/domain/UserServiceImplTest.java
@@ -719,7 +719,7 @@ class UserServiceImplTest {
 
         // Then
         assertAll(
-                () -> assertThat(profileEmailServiceResponse.getEmail()).isEqualTo("")
+                () -> assertThat(profileEmailServiceResponse.getEmail()).isEmpty()
         );
 
         verify(userRepository).findByLoginId(LOGIN_ID);

--- a/user-service/src/test/java/kr/mybrary/userservice/user/domain/UserServiceImplTest.java
+++ b/user-service/src/test/java/kr/mybrary/userservice/user/domain/UserServiceImplTest.java
@@ -692,6 +692,40 @@ class UserServiceImplTest {
     }
 
     @Test
+    @DisplayName("로그인 아이디로 사용자의 로그인된 이메일 계정을 조회한다")
+    void getProfileEmail() {
+        // Given
+        given(userRepository.findByLoginId(LOGIN_ID)).willReturn(Optional.of(UserFixture.COMMON_USER.getUser()));
+
+        // When
+        ProfileEmailServiceResponse profileEmailServiceResponse = userService.getProfileEmail(LOGIN_ID);
+
+        // Then
+        assertAll(
+                () -> assertThat(profileEmailServiceResponse.getEmail()).isEqualTo(UserFixture.COMMON_USER.getUser().getEmail())
+        );
+
+        verify(userRepository).findByLoginId(LOGIN_ID);
+    }
+
+    @Test
+    @DisplayName("로그인 아이디로 사용자의 로그인된 이메일 계정을 조회할 때, 이메일이 없으면 빈 문자열을 반환한다")
+    void getProfileEmailWithNoEmail() {
+        // Given
+        given(userRepository.findByLoginId(LOGIN_ID)).willReturn(Optional.of(UserFixture.USER_WITH_NO_EMAIL.getUser()));
+
+        // When
+        ProfileEmailServiceResponse profileEmailServiceResponse = userService.getProfileEmail(LOGIN_ID);
+
+        // Then
+        assertAll(
+                () -> assertThat(profileEmailServiceResponse.getEmail()).isEqualTo("")
+        );
+
+        verify(userRepository).findByLoginId(LOGIN_ID);
+    }
+
+    @Test
     @DisplayName("로그인 아이디로 사용자의 팔로워 목록을 조회한다")
     void getFollowers() {
         // Given

--- a/user-service/src/test/java/kr/mybrary/userservice/user/presentation/UserControllerTest.java
+++ b/user-service/src/test/java/kr/mybrary/userservice/user/presentation/UserControllerTest.java
@@ -25,21 +25,12 @@ import java.util.ArrayList;
 import java.util.List;
 import kr.mybrary.userservice.user.domain.UserService;
 import kr.mybrary.userservice.user.domain.dto.request.*;
-import kr.mybrary.userservice.user.domain.dto.response.FollowResponse;
-import kr.mybrary.userservice.user.domain.dto.response.FollowStatusServiceResponse;
-import kr.mybrary.userservice.user.domain.dto.response.FollowerServiceResponse;
-import kr.mybrary.userservice.user.domain.dto.response.FollowingServiceResponse;
-import kr.mybrary.userservice.user.domain.dto.response.ProfileImageUrlServiceResponse;
-import kr.mybrary.userservice.user.domain.dto.response.ProfileServiceResponse;
-import kr.mybrary.userservice.user.domain.dto.response.SearchServiceResponse;
-import kr.mybrary.userservice.user.domain.dto.response.SignUpServiceResponse;
-import kr.mybrary.userservice.user.domain.dto.response.UserInfoServiceResponse;
+import kr.mybrary.userservice.user.domain.dto.response.*;
 import kr.mybrary.userservice.user.persistence.Role;
 import kr.mybrary.userservice.user.presentation.dto.request.FollowRequest;
 import kr.mybrary.userservice.user.presentation.dto.request.FollowerRequest;
 import kr.mybrary.userservice.user.presentation.dto.request.ProfileUpdateRequest;
 import kr.mybrary.userservice.user.presentation.dto.request.SignUpRequest;
-import kr.mybrary.userservice.user.presentation.dto.request.UserInfoRequest;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -474,6 +465,55 @@ class UserControllerTest {
                                                 .description(MESSAGE_FIELD_DESCRIPTION),
                                         fieldWithPath("data.profileImageUrl").type(
                                                 JsonFieldType.STRING).description("기본 프로필 이미지 URL")
+                                )
+                                .build()
+                ))
+        );
+    }
+
+    @DisplayName("사용자의 로그인된 이메일 계정을 조회한다.")
+    @Test
+    void getProfileEmail() throws Exception {
+        // given
+        ProfileEmailServiceResponse profileEmailServiceResponse = ProfileEmailServiceResponse.builder()
+                .email("user@email")
+                .build();
+
+        given(userService.getProfileEmail(anyString())).willReturn(profileEmailServiceResponse);
+
+        // when
+        ResultActions actions = mockMvc.perform(
+                RestDocumentationRequestBuilders.get(BASE_URL+"/{userId}/profile/email", USER_ID));
+
+        // then
+        actions
+                .andExpect(status().is2xxSuccessful())
+                .andExpect(jsonPath("$.status").value(HttpStatus.OK.toString()))
+                .andExpect(jsonPath("$.message").value("사용자의 로그인된 이메일 계정을 조회했습니다."))
+                .andExpect(jsonPath("$.data.email").value(profileEmailServiceResponse.getEmail()));
+
+        verify(userService).getProfileEmail(anyString());
+
+        // docs
+        actions.andDo(document("get-user-profile-email",
+                preprocessRequest(prettyPrint()),
+                preprocessResponse(prettyPrint()),
+                resource(
+                        ResourceSnippetParameters.builder()
+                                .tag("user-profile")
+                                .summary("사용자의 로그인된 이메일 계정을 조회한다.")
+                                .pathParameters(
+                                        parameterWithName("userId").description("사용자 아이디")
+                                )
+                                .responseSchema(
+                                        Schema.schema("get_user_profile_email_response_body"))
+                                .responseFields(
+                                        fieldWithPath("status").type(JsonFieldType.STRING)
+                                                .description(STATUS_FIELD_DESCRIPTION),
+                                        fieldWithPath("message").type(JsonFieldType.STRING)
+                                                .description(MESSAGE_FIELD_DESCRIPTION),
+                                        fieldWithPath("data.email").type(
+                                                JsonFieldType.STRING).description("사용자의 로그인된 이메일 계정")
                                 )
                                 .build()
                 ))


### PR DESCRIPTION
## 🧑‍💻 작업 사항

### 소셜 로그인 이메일 조회 API
환경설정 탭에서 소셜 로그인 정보를 조회할 수 있도록 이메일 조회 API를 구현했습니다.
(애플 소셜로그인 이슈 처리때문에 개발이 늦어져서 대단히 죄송합니다 😅)
- 요청
```
GET http://mybrary.kr/user-service/api/v1/users/{userId}/profile/email
```

- 응답
```
{
  "status": "200 OK",
  "message": "사용자의 로그인된 이메일 계정을 조회했습니다.",
  "data": {
    "email": "email@mybrary.com"
  }
}
```

### 소셜 로그인 실패 시 예외 처리 변경
- 기존
<img width="1290" alt="image" src="https://github.com/SWM-IDLE/mybrary-user-service/assets/78717113/bceb4c40-06c0-4f34-92b5-c42a354e8c3b">

- 응답 body로 errorCode, errorMessage 전달
- 모바일 환경에서, 웹뷰에 던져진 errorCode, errorMessage를 읽어올 수 없는 문제 발생
- 따라서 소셜 로그인 성공 시 accessToken, refreshToken을 전달하는 방법처럼,
- 예외 발생 시 errorCode, errorMessage를 redirect url의 파라미터로 전달되도록 수정

<br>


- 변경
<img width="1512" alt="image" src="https://github.com/SWM-IDLE/mybrary-user-service/assets/78717113/9104ce96-a693-40c2-a4ed-2d1df996be17">

- kr.mybrary://?errorCode={errorCode}&errorMessage={errorMessage} 형식으로 리턴
- 클라이언트에서 에러 파라미터를 잘 전달 받아서 예외 처리가 잘 수행되면 좋겠습니다!! 😄


<!-- 어떤 변경사항이 있는지, PR 타이틀과 동일하다면 Skip -->

<br><br>

## 🔗 링크

<!-- 관련된 대화가 이루어진 슬랙 링크 혹은 피그마 링크를 첨부. -->
<!-- - [프레이머](https://framer.com/projects/2--gSDcZoNKqU6dqCUQUYQe-53rEr?node=tQMWSSKqy)  -->

<br><br>

## 🐰 시급한 정도
🏃‍♂️ 보통 : 최대한 빠르게 리뷰 부탁드립니다. 
<!-- 🚨 긴급 : 선 어프루브 후 리뷰를 부탁드립니다. (리뷰는 추후 반영)  -->
<!-- 🐢 천천히 : 급하지 않습니다. -->

<br><br>

## 📖 참고 사항

<!-- 공유할 내용, 레퍼런스, 추가로 발생할 것으로 예상되는 이슈, 스크린샷 등을 넣어 주세요.  -->
<!-- 변경사항이 큰 경우 집중해야 할 부분, 또는 불안해서 봐주었으면 하는 부분 등 -->
