### PR TITLE
[IDLE-290] hotfix: ECS 서버 시간 설정

### DIFF
--- a/user-service/task-definition.json
+++ b/user-service/task-definition.json
@@ -19,6 +19,10 @@
         {
           "name": "CONFIG_SERVER_URI",
           "value": "http://10.0.3.105:8888"
+        },
+        {
+          "name": "TZ",
+          "value": "Asia/Seoul"
         }
       ],
       "mountPoints": [],


### PR DESCRIPTION
## 🧑‍💻 작업 사항

<!-- 어떤 변경사항이 있는지, PR 타이틀과 동일하다면 Skip -->
### task-definition.json에 서버 시간 설정을 위한 환경변수 추가 
```
{
  "containerDefinitions": [
    {
      "name": "your-container-name",
      "image": "your-container-image",
      "environment": [
        {
          "name": "TZ",
          "value": "Asia/Seoul"  // 원하는 타임존을 설정
        }
      ],
      // 다른 컨테이너 설정
    }
  ],
  // 다른 작업 정의 설정
}
```

<br><br>

## 🔗 링크

<!-- 관련된 대화가 이루어진 슬랙 링크 혹은 피그마 링크를 첨부. -->
<!-- - [프레이머](https://framer.com/projects/2--gSDcZoNKqU6dqCUQUYQe-53rEr?node=tQMWSSKqy)  -->

<br><br>

## 🐰 시급한 정도

<!-- 🏃‍♂️ 보통 : 최대한 빠르게 리뷰 부탁드립니다. -->
🚨 긴급 : 선 어프루브 후 리뷰를 부탁드립니다. (리뷰는 추후 반영)
<!-- 🐢 천천히 : 급하지 않습니다. -->

<br><br>

## 📖 참고 사항

<!-- 공유할 내용, 레퍼런스, 추가로 발생할 것으로 예상되는 이슈, 스크린샷 등을 넣어 주세요.  -->
<!-- 변경사항이 큰 경우 집중해야 할 부분, 또는 불안해서 봐주었으면 하는 부분 등 -->
